### PR TITLE
Add EXPOSE to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,6 @@ RUN groupadd ${USER} \
     chown -R ${USER}:${USER} /bin
 
 USER ${USER}
+EXPOSE 8000
 
 ENTRYPOINT ["./server"]


### PR DESCRIPTION
This service runs on port 8000, but the Dockerfile does not advertise that. There are some hosting services (like [Zeet](https://zeet.co)) that detect the exposed ports and use that to setup configuration.

I created this fork while writing [this article](https://blog.zeet.co/df-remote-explorer/) about how to run a Remote Explorer for Dark Forest on Zeet 